### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that connects to Vercel API.
 
+<a href="https://glama.ai/mcp/servers/@ZukAi-MCP/vercel-api-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ZukAi-MCP/vercel-api-mcp/badge" alt="Vercel MCP server" />
+</a>
+
 ## Usage
 
 ### Cursor
@@ -86,4 +90,3 @@ This MCP server provides the following tools for interacting with the Vercel API
 - `createVercelProjectEnv` - Create one or more environment variables
 - `removeVercelProjectEnv` - Remove an environment variable
 - `editVercelProjectEnv` - Edit an environment variable
-


### PR DESCRIPTION
This PR adds a badge for the [Vercel MCP](https://glama.ai/mcp/servers/@ZukAi-MCP/vercel-api-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ZukAi-MCP/vercel-api-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ZukAi-MCP/vercel-api-mcp/badge" alt="Vercel MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.